### PR TITLE
Add a cli flag for sarif-to-comment to define report titles

### DIFF
--- a/packages/sarif-to-comment/README.md
+++ b/packages/sarif-to-comment/README.md
@@ -28,6 +28,8 @@ Install with [npm](https://www.npmjs.com/):
       --action                      Authentication mode for the token, defaults to PAT, if set, switches to Github Action
       --ruleDetails                 Include rule details in the markdown, might be too big for Github's API, defaults to false
       --commentUrl                  Post to comment URL. e.g. https://github.com/owner/repo/issues/85
+      --title                       Specify a comment title for the report, optional
+      --no-suppressedResults        Don't include suppressed results, that are in SARIF suppressions
       --sarifContentOwner           GitHub Owner name of sarif content result.  e.g. "owner"
       --sarifContentRepo            GitHub Repository name of sarif content result. e.g. "repo"
       --sarifContentBranch          GitHub Repository branch name of sarif content result. e.g. "master"

--- a/packages/sarif-to-comment/src/cli.ts
+++ b/packages/sarif-to-comment/src/cli.ts
@@ -16,6 +16,7 @@ export function run() {
       --token                       GitHub Token, or support environment variables - GITHUB_TOKEN=xxx
       --action                      Authentication mode for the token, defaults to PAT, if set, switches to Github Action
       --ruleDetails                 Include rule details in the markdown, might be too big for Github's API, defaults to false
+      --title                       Specify a comment title for the report, optional
       --no-suppressedResults        Don't include suppressed results, that are in SARIF suppressions
       --commentUrl                  Post to comment URL. e.g. https://github.com/owner/repo/issues/85
       --sarifContentOwner           GitHub Owner name of sarif content result.  e.g. "owner"
@@ -43,6 +44,9 @@ export function run() {
                 ruleDetails: {
                     type: "boolean",
                     default: false
+                },
+                title: {
+                    type: "string"
                 },
                 dryRun: {
                     type: "boolean"
@@ -97,7 +101,8 @@ export function run() {
             sarifContentSourceRoot: cli.flags.sarifContentSourceRoot,
             ghActionAuthenticationMode: cli.flags.action,
             ruleDetails: cli.flags.ruleDetails,
-            suppressedResults: cli.flags.suppressedResults
+            suppressedResults: cli.flags.suppressedResults,
+            title: cli.flags.title
         }).then((result) => {
             if (!result) {
                 return "";


### PR DESCRIPTION
This might have been a missing feature, the option was just missing from the cli https://github.com/azu/security-alert/issues/17