### PR TITLE
Don't comment if no results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: yarn install
+      - name: Build
+        run: yarn run build # it generates .d.ts files
       - name: Test
         run: yarn test

--- a/packages/sarif-to-comment/package.json
+++ b/packages/sarif-to-comment/package.json
@@ -39,7 +39,7 @@
     "build": "tsc -p . && tsc --project ./tsconfig.module.json",
     "clean": "rimraf lib/ module/",
     "prepublish": "npm run --if-present build",
-    "test": "exit 0",
+    "test": "mocha \"test/**/*.ts\"",
     "watch": "tsc -p . --watch"
   },
   "dependencies": {

--- a/packages/sarif-to-comment/src/cli.ts
+++ b/packages/sarif-to-comment/src/cli.ts
@@ -2,6 +2,7 @@ import meow from "meow";
 import { postComment } from "./index";
 import * as fs from "fs";
 const ALLOWED_SEVERITIES = ["warning", "error", "note", "none"] as const;
+
 export function run() {
     const cli = meow(
         `
@@ -108,9 +109,9 @@ export function run() {
             cli.showHelp(1);
         }
     }
-    const promises = cli.input.map((sarifFilePath) => {
+    const promises = cli.input.map(async (sarifFilePath) => {
         const content = fs.readFileSync(sarifFilePath, "utf-8");
-        return postComment({
+        return await postComment({
             token: token,
             dryRun: cli.flags.dryRun,
             postingURL: cli.flags.commentUrl,
@@ -129,10 +130,18 @@ export function run() {
             if (!result) {
                 return "";
             }
-            return result.html_url;
+            return result;
         });
     });
-    return Promise.all(promises).then((issuesURL) => {
-        return issuesURL.join("\n");
+    return Promise.all(promises).then((commentsResults: any) => {
+        const postedURLS = commentsResults.filter((c: any) => c.posted);
+        const emptyURLS = commentsResults.filter((c: any) => !c.posted);
+        if (emptyURLS.length > 0) {
+            console.log("Some comments were not posted, here are the reasons:");
+            emptyURLS.forEach((val: any) => console.log(val.reason));
+            console.log(postedURLS.join("\n"));
+            process.exit(0);
+        }
+        return postedURLS.join("\n");
     });
 }

--- a/packages/sarif-to-comment/src/cli.ts
+++ b/packages/sarif-to-comment/src/cli.ts
@@ -134,14 +134,16 @@ export function run() {
         });
     });
     return Promise.all(promises).then((commentsResults: any) => {
-        const postedURLS = commentsResults.filter((c: any) => c.posted);
-        const emptyURLS = commentsResults.filter((c: any) => !c.posted);
-        if (emptyURLS.length > 0) {
-            console.log("Some comments were not posted, here are the reasons:");
-            emptyURLS.forEach((val: any) => console.log(val.reason));
-            console.log(postedURLS.join("\n"));
-            process.exit(0);
+        const postedURLS = commentsResults.map((c: any) => {
+            if (c.posted) return c.commentUrl;
+        });
+        const emptyURLReasons = commentsResults.map((c: any) => {
+            if (!c.posted) return c.reason;
+        });
+
+        if (emptyURLReasons.length > 0) {
+            console.log("Some comments were not posted, reasons will be included");
         }
-        return postedURLS.join("\n");
+        return (postedURLS + emptyURLReasons).join("\n");
     });
 }

--- a/packages/sarif-to-comment/src/example.ts
+++ b/packages/sarif-to-comment/src/example.ts
@@ -444,5 +444,9 @@ postComment({
     token: process.env.GITHUB_TOKEN!,
     dryRun: false
 }).then((res) => {
-    console.log(res?.html_url);
+    if (res.posted) {
+        console.log(res?.commentUrl);
+    } else {
+        console.log(res?.reason);
+    }
 });

--- a/packages/sarif-to-comment/src/index.ts
+++ b/packages/sarif-to-comment/src/index.ts
@@ -35,12 +35,16 @@ export async function postComment(options: CreatedOptions) {
     const issuePattern =
         /^https:\/\/github.com\/(?<owner>[0-9a-zA-Z-_.]+)\/(?<repo>[0-9a-zA-Z-_.]+)\/issues\/(?<issueNumber>[0-9]+)/;
     const matchObj = issuePattern.exec(options.postingURL);
+    const content = JSON.parse(options.sarifContent);
     if (!matchObj || !matchObj.groups) {
         throw new Error(
             "Should set security alert url.\n" +
                 "\n" +
                 "Example: https://github.com/owner/reponame/network/alert/package-lock.json/axios/open"
         );
+    }
+    if (content?.runs?.[0]?.results.length === 0) {
+        throw new Error("There are no results in this SARIF run 0, exiting without a comment !");
     }
     const postingOwner: string = matchObj.groups.owner;
     const postringRepo: string = matchObj.groups.repo;

--- a/packages/sarif-to-comment/src/index.ts
+++ b/packages/sarif-to-comment/src/index.ts
@@ -46,7 +46,7 @@ export async function postComment(options: CreatedOptions): Promise<PostedCommen
         );
     }
     if (content?.runs?.[0]?.results.length === 0) {
-        return { posted: false, reason: "There are no results in this SARIF run 0, exiting without a comment ! " };
+        return { posted: false, reason: "There are no results in this SARIF run 0, exiting without a comment !" };
     }
     const postingOwner: string = matchObj.groups.owner;
     const postringRepo: string = matchObj.groups.repo;
@@ -70,7 +70,7 @@ export async function postComment(options: CreatedOptions): Promise<PostedCommen
         .join("\n\n");
     if (dryRun) {
         if (resultsHasMessage.length === 0) {
-            console.log("It will not post, because the content has not results.");
+            console.log("It will not post, because the markdown is empty");
         }
         console.log(`DryRun results:
 owner: ${owner}

--- a/packages/sarif-to-comment/src/index.ts
+++ b/packages/sarif-to-comment/src/index.ts
@@ -26,7 +26,9 @@ export type CreatedOptions = {
     severity?: readonly string[];
 };
 
-export async function postComment(options: CreatedOptions) {
+export type PostedCommentResult = { posted: true; commentUrl: string } | { posted: false; reason: string };
+
+export async function postComment(options: CreatedOptions): Promise<PostedCommentResult> {
     const dryRun = options.dryRun !== undefined ? options.dryRun : false;
     const owner = options.sarifContentOwner;
     const repo = options.sarifContentRepo;
@@ -44,7 +46,7 @@ export async function postComment(options: CreatedOptions) {
         );
     }
     if (content?.runs?.[0]?.results.length === 0) {
-        throw new Error("There are no results in this SARIF run 0, exiting without a comment !");
+        return { posted: false, reason: "There are no results in this SARIF run 0, exiting without a comment ! " };
     }
     const postingOwner: string = matchObj.groups.owner;
     const postringRepo: string = matchObj.groups.repo;
@@ -77,12 +79,12 @@ issue: ${options.postingURL}
 title: ${options.title}
 body: ${body}
 `);
-        return;
+        return { posted: false, reason: "This is a dry run" };
     } else {
         if (resultsHasMessage.length === 0) {
-            return;
+            return { posted: false, reason: "Markdown extracted from SARIF was empty" };
         }
-        return issueComment({
+        const url = await issueComment({
             owner: postingOwner,
             repo: postringRepo,
             issue_number: postringNumber,
@@ -90,5 +92,7 @@ body: ${body}
             token: options.token,
             ghActionAuthentication: options.ghActionAuthenticationMode
         });
+        console.log(url);
+        return { posted: true, commentUrl: url.html_url.toString() };
     }
 }

--- a/packages/sarif-to-comment/test/empty-comment.test.ts
+++ b/packages/sarif-to-comment/test/empty-comment.test.ts
@@ -17,15 +17,11 @@ describe("Testing", () => {
             sarifContentBranch: "aa",
             token: "aa"
         };
+        const result = await postComment(actualOptions);
 
-        await assert.rejects(
-            async () => {
-                await postComment(actualOptions);
-            },
-            {
-                name: "Error", //  error type
-                message: "There are no results in this SARIF run 0, exiting without a comment !" // error message
-            }
-        );
+        assert.deepStrictEqual(result, {
+            posted: false, //  error type
+            reason: "There are no results in this SARIF run 0, exiting without a comment !" // error message
+        });
     });
 });

--- a/packages/sarif-to-comment/test/empty-comment.test.ts
+++ b/packages/sarif-to-comment/test/empty-comment.test.ts
@@ -4,7 +4,6 @@ import * as assert from "assert";
 // transform function
 import { postComment } from "../src/index";
 
-console.log(__dirname);
 const sarifDir = path.join(__dirname);
 const actualFilePath = path.join(sarifDir, "sarif.json");
 

--- a/packages/sarif-to-comment/test/empty-comment.test.ts
+++ b/packages/sarif-to-comment/test/empty-comment.test.ts
@@ -6,20 +6,27 @@ import { postComment } from "../src/index";
 
 console.log(__dirname);
 const sarifDir = path.join(__dirname);
-const actualFilePath = path.join(sarifDir, "/sarif.json");
+const actualFilePath = path.join(sarifDir, "sarif.json");
+
 describe("Testing", () => {
     it(`Testing failure due to empty sarif`, async function () {
         const actualOptions = {
-            sarifContent: JSON.parse(fs.readFileSync(actualFilePath).toString()),
-            postingURL: "http://localhost",
+            sarifContent: fs.readFileSync(actualFilePath, "utf-8"),
+            postingURL: "https://github.com/azu/security-alert/issues/1",
             sarifContentOwner: "aa",
             sarifContentRepo: "aa",
             sarifContentBranch: "aa",
             token: "aa"
         };
 
-        assert.throws(async () => {
-            await postComment(actualOptions);
-        }, "There are no results in this SARIF run 0, exiting without a comment !");
+        await assert.rejects(
+            async () => {
+                await postComment(actualOptions);
+            },
+            {
+                name: "Error", //  error type
+                message: "There are no results in this SARIF run 0, exiting without a comment !" // error message
+            }
+        );
     });
 });

--- a/packages/sarif-to-comment/test/empty-comment.test.ts
+++ b/packages/sarif-to-comment/test/empty-comment.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as assert from "assert";
+// transform function
+import { postComment } from "../src/index";
+
+console.log(__dirname);
+const sarifDir = path.join(__dirname);
+const actualFilePath = path.join(sarifDir, "/sarif.json");
+describe("Testing", () => {
+    it(`Testing failure due to empty sarif`, async function () {
+        const actualOptions = {
+            sarifContent: JSON.parse(fs.readFileSync(actualFilePath).toString()),
+            postingURL: "http://localhost",
+            sarifContentOwner: "aa",
+            sarifContentRepo: "aa",
+            sarifContentBranch: "aa",
+            token: "aa"
+        };
+
+        assert.throws(async () => {
+            await postComment(actualOptions);
+        }, "There are no results in this SARIF run 0, exiting without a comment !");
+    });
+});

--- a/packages/sarif-to-comment/test/sarif.json
+++ b/packages/sarif-to-comment/test/sarif.json
@@ -1,0 +1,54 @@
+{
+    "$schema" : "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "version" : "2.1.0",
+    "runs" : [ {
+      "tool" : {
+        "driver" : {
+          "name" : "CodeQL command-line toolchain",
+          "organization" : "GitHub",
+          "semanticVersion" : "2.2.4",
+          "rules" : [ {
+            "id" : "js/xss",
+            "name" : "js/xss",
+            "shortDescription" : {
+              "text" : "Client-side cross-site scripting"
+            },
+            "fullDescription" : {
+              "text" : "Writing user input directly to the DOM allows for a cross-site scripting vulnerability."
+            },
+            "defaultConfiguration" : {
+              "level" : "error"
+            },
+            "properties" : {
+              "tags" : [ "security", "external/cwe/cwe-079", "external/cwe/cwe-116" ],
+              "kind" : "path-problem",
+              "precision" : "high",
+              "name" : "Client-side cross-site scripting",
+              "description" : "Writing user input directly to the DOM allows for\n              a cross-site scripting vulnerability.",
+              "id" : "js/xss",
+              "problem.severity" : "error"
+            }
+          } ]
+        }
+      },
+      "artifacts" : [ {
+        "location" : {
+          "uri" : "examples/Xss.js",
+          "uriBaseId" : "%SRCROOT%",
+          "index" : 0
+        }
+      }, {
+        "location" : {
+          "uri" : "examples/Xss2.js",
+          "uriBaseId" : "%SRCROOT%",
+          "index" : 1
+        }
+      } ],
+      "results" : [],
+      "newlineSequences" : [ "\r\n", "\n", " ", " " ],
+      "columnKind" : "utf16CodeUnits",
+      "properties" : {
+        "semmle.formatSpecifier" : "sarifv2.1.0"
+      }
+    } ]
+  }


### PR DESCRIPTION
Fixes https://github.com/azu/security-alert/issues/6, I think I could improve that by not returning an error code even if it's an error ? It would fail in CI pipelines if we return an error code, not ideal
@azu Can you help on the mocha testing ? The assert.throws is not working, it's weird