### PR TITLE
Bugfix: empty comments reason logs

### DIFF
--- a/packages/sarif-to-comment/src/cli.ts
+++ b/packages/sarif-to-comment/src/cli.ts
@@ -144,6 +144,6 @@ export function run() {
         if (emptyURLReasons.length > 0) {
             console.log("Some comments were not posted, reasons will be included");
         }
-        return (postedURLS + emptyURLReasons).join("\n");
+        return postedURLS.concat(emptyURLReasons).join("\n");
     });
 }

--- a/packages/sarif-to-comment/src/cli.ts
+++ b/packages/sarif-to-comment/src/cli.ts
@@ -134,13 +134,16 @@ export function run() {
         });
     });
     return Promise.all(promises).then((commentsResults: any) => {
-        const postedURLS = commentsResults.map((c: any) => {
-            if (c.posted) return c.commentUrl;
-        });
-        const emptyURLReasons = commentsResults.map((c: any) => {
-            if (!c.posted) return c.reason;
-        });
-
+        const postedURLS = commentsResults
+            .filter((c: any) => c.posted === true)
+            .map((c: any) => {
+                if (c.posted) return c.commentUrl;
+            });
+        const emptyURLReasons = commentsResults
+            .filter((c: any) => c.posted === false)
+            .map((c: any) => {
+                if (c.posted === false) return c.reason;
+            });
         if (emptyURLReasons.length > 0) {
             console.log("Some comments were not posted, reasons will be included");
         }

--- a/packages/sarif-to-comment/src/index.ts
+++ b/packages/sarif-to-comment/src/index.ts
@@ -92,7 +92,6 @@ body: ${body}
             token: options.token,
             ghActionAuthentication: options.ghActionAuthenticationMode
         });
-        console.log(url);
         return { posted: true, commentUrl: url.html_url.toString() };
     }
 }


### PR DESCRIPTION
Fixes https://github.com/azu/security-alert/issues/26
The mistake was on the filtering of non-posted URLs, and the concat issue mainly